### PR TITLE
Default CPU request value

### DIFF
--- a/components/operator/controller/defaults.go
+++ b/components/operator/controller/defaults.go
@@ -12,6 +12,7 @@ var (
 		Resources: &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
 				"memory": resource.MustParse("64Mi"),
+				"cpu":    resource.MustParse("100m"),
 			},
 			Limits: v1.ResourceList{
 				"memory": resource.MustParse("128Mi"),
@@ -56,6 +57,7 @@ var (
 		Resources: &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
 				"memory": resource.MustParse("64Mi"), // 90% of limit, used to set GOMEMLIMIT
+				"cpu":    resource.MustParse("100m"),
 			},
 			Limits: v1.ResourceList{
 				"memory": resource.MustParse("160Mi"),
@@ -82,6 +84,7 @@ var (
 		Resources: &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
 				"memory": resource.MustParse("64Mi"),
+				"cpu":    resource.MustParse("100m"),
 			},
 			Limits: v1.ResourceList{
 				"memory": resource.MustParse("160Mi"),


### PR DESCRIPTION
Set a default CPU Request value for controller managed objects - NATS, Broker, HTTPSrv