### PR TITLE
Set HTTP Response attributes on telemetry spans

### DIFF
--- a/components/httpsrv/adapter/server.go
+++ b/components/httpsrv/adapter/server.go
@@ -175,6 +175,10 @@ func (srv *Server) ServeHTTP(resWriter http.ResponseWriter, httpReq *http.Reques
 
 		rootSpan.SetEventAttributes(req)
 		respSpan.SetEventAttributes(resp)
+		httpResp := resp.HTTPResponse()
+
+		rootSpan.SetHTTPResponseAttributes(httpResp)
+		respSpan.SetHTTPResponseAttributes(httpResp)
 
 		rootSpan.End()
 

--- a/telemetry/trace.go
+++ b/telemetry/trace.go
@@ -13,6 +13,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/rand"
+	"net/http"
 	"reflect"
 	sync "sync"
 	"time"
@@ -229,6 +230,17 @@ func (s *Span) SetEventAttributes(evt *core.Event) {
 	for _, child := range s.ChildSpans {
 		child.SetEventAttributes(evt)
 	}
+}
+
+func (s *Span) SetHTTPResponseAttributes(httpResp *http.Response) {
+	if s == nil || httpResp == nil {
+		return
+	}
+
+	s.SetAttributes(
+		Attr(AttrKeyHTTPRespStatusCode, httpResp.StatusCode),
+		Attr(AttrKeyHTTPRespBodySize, httpResp.ContentLength),
+	)
 }
 
 func (s *Span) Record() bool {


### PR DESCRIPTION
@xadhatter Do you think that this should go within it's own function (Like I wrote), or would this make more sense to live within `func (s *Span) SetEventAttributes(evt *core.Event) {`?

**Problem:**

1. When an HTTP response is created no information is attached to the spans that are created.

**Solution:**

1. Adding a method to pull out the HTTP response and set some attributes about the response on both the parent span, and the response span.

**Testing:**

1. I verified that the content is set on both the root and the response spans (Via Signoz):
![image](https://github.com/user-attachments/assets/564d2115-cac2-4261-8b61-c2dd5a71fa12)

![image](https://github.com/user-attachments/assets/c7bb0ac1-50c5-4084-9590-c3d9eb265a12)
